### PR TITLE
add ratelimit headers

### DIFF
--- a/horde/limiter.py
+++ b/horde/limiter.py
@@ -16,7 +16,8 @@ if is_redis_up():
             storage_uri=ger_limiter_url(),
             # storage_options={"connect_timeout": 30},
             strategy="fixed-window", # or "moving-window"
-            default_limits=["90 per minute"]
+            default_limits=["90 per minute"],
+            headers_enabled=True
         )
         logger.init_ok("Limiter Cache", status="Connected")
     except:
@@ -26,6 +27,7 @@ if limiter == None:
     limiter = Limiter(
         HORDE,
         key_func=get_remote_address,
-        default_limits=["90 per minute"]
+        default_limits=["90 per minute"],
+        headers_enabled=True
     )
     logger.init_warn("Limiter Cache", status="Memory Only")


### PR DESCRIPTION
This adds three headers for rate limited routes after a limit occurs: `X-RateLimit-Limit`, `X-RateLimit-Remaining`, and `X-RateLimit-Reset`