### PR TITLE
Add flag for embeds

### DIFF
--- a/horde/apis/models/stable_v2.py
+++ b/horde/apis/models/stable_v2.py
@@ -47,6 +47,7 @@ class Models(v2.Models):
             'ddim_steps': fields.Integer(default=30), 
             'n_iter': fields.Integer(default=1, description="The amount of images to generate"), 
             'use_nsfw_censor': fields.Boolean(description="When true will apply NSFW censoring model on the generation"),
+            'use_embeds': fields.Boolean(default=False, description="When true will use embeddings from the concepts library when doing the generation"),
         })
         self.input_model_generation_payload = api.inherit('ModelGenerationInputStable', self.root_model_generation_payload_stable, {
             'steps': fields.Integer(default=30, required=False, min = 1, max=500), 


### PR DESCRIPTION
Adding a flag for embeds so users can turn on/off whether the images are generated with embeds or not - plan is to have the workers load up the sd-concepts-library on start, and then at generation time, if the flag is checked, compare the prompt with db_embeds.json (that catalogs the library in the same way db.json does for models), and if it exists, check that embed's baseline matches the baseline of the model, and if so load the embed for the generation.