### PR TITLE
Added support for the sampler_order field in generation params. It's …

### DIFF
--- a/horde/apis/models/kobold_v2.py
+++ b/horde/apis/models/kobold_v2.py
@@ -44,6 +44,7 @@ class Models(v2.Models):
             'top_k': fields.Integer(description="Top-k sampling value."), 
             'top_p': fields.Float(description="Top-p sampling value."), 
             'typical': fields.Float(description="Typical sampling value."), 
+            'sampler_order': fields.List(fields.Integer(description="Array of integers representing the sampler order to be used")),
         })
         self.response_model_generation_payload = api.inherit('ModelPayloadKobold', self.root_model_generation_payload_kobold, {
             'prompt': fields.String(description="The prompt which will be sent to Kobold Diffusion to generate an image"),


### PR DESCRIPTION
Added support for the sampler_order field in generation params. 
It's an array of ints as described in the api, would look something like this: [6, 0, 1, 2, 3, 4, 5]

this will resolve the issue opened for  https://github.com/db0/AI-Horde/issues/136 

