### PR TITLE
add 'allow_post_processing' to worker get_details()

### DIFF
--- a/horde/classes/stable/worker.py
+++ b/horde/classes/stable/worker.py
@@ -122,6 +122,7 @@ class WorkerExtended(Worker):
         allow_painting = self.allow_painting
         if self.bridge_version < 4: allow_painting = False
         ret_dict["painting"] = allow_painting
+        ret_dict["allow_post_processing"] = self.allow_post_processing
         return ret_dict
 
     def parse_models(self, models):

--- a/horde/classes/stable/worker.py
+++ b/horde/classes/stable/worker.py
@@ -15,7 +15,7 @@ class WorkerExtended(Worker):
     max_pixels = db.Column(db.Integer, default=512 * 512, nullable=False)
     allow_img2img = db.Column(db.Boolean, default=True, nullable=False)
     allow_painting = db.Column(db.Boolean, default=True, nullable=False)
-    allow_post_processing = True
+    allow_post_processing = db.Column(db.Boolean, default=True, nullable=False)
 
     def check_in(self, max_pixels, **kwargs):
         super().check_in(**kwargs)
@@ -122,7 +122,7 @@ class WorkerExtended(Worker):
         allow_painting = self.allow_painting
         if self.bridge_version < 4: allow_painting = False
         ret_dict["painting"] = allow_painting
-        ret_dict["allow_post_processing"] = self.allow_post_processing
+        ret_dict["post-processing"] = self.allow_post_processing        
         return ret_dict
 
     def parse_models(self, models):


### PR DESCRIPTION
See #158.

This (very small) change would update the endpoints which return worker details (including https://stablehorde.net/api/v2/workers) to show each (or the one) worker's ability to post process, aiding front ends in determining if a given request is possible under current horde conditions.