### PR TITLE
feat: add feature references for sd-webui-bridge

### DIFF
--- a/horde/bridge_reference.py
+++ b/horde/bridge_reference.py
@@ -13,8 +13,8 @@ BRIDGE_CAPABILITIES = {
         3: {"img2img"},
     },
     "SD-WebUI Stable Horde Worker Bridge": {
-        4: {"r2_source"},
-        3: {"hires_fix", "clip_skip"},
+        4: {"hires_fix", "clip_skip"},
+        3: {"r2_source"},
         2: {"tiling"},
         1: {
             # "img2img",

--- a/horde/bridge_reference.py
+++ b/horde/bridge_reference.py
@@ -13,6 +13,8 @@ BRIDGE_CAPABILITIES = {
         3: {"img2img"},
     },
     "SD-WebUI Stable Horde Worker Bridge": {
+        4: {"r2_source"},
+        3: {"hires_fix", "clip_skip"},
         2: {"tiling"},
         1: {
             # "img2img",


### PR DESCRIPTION
It is not implemented currently, but in the plan.

Question: `r2_source` means that the `source_image` in the response JSON when the user using img2img would be an HTTP link rather than a base64 string?